### PR TITLE
WIP: Replace hard-coded python file with subprocess

### DIFF
--- a/org-opml.el
+++ b/org-opml.el
@@ -1,20 +1,20 @@
 ;; Locate the OPML import backend
 (setq opml2org (locate-file "opml2org.py" load-path))
 
-(defun opml-decode (begin end)
-  (call-process-region
-   (point-min) (point-max)
-   opml2org
-   ;; three 't's = redisplay buffer with processed text
-   t t t))
+;; (defun opml-decode (begin end)
+;;  (call-process-region
+;;   (point-min) (point-max)
+;;   opml2org
+;;   ;; three 't's = redisplay buffer with processed text
+;;   t t t))
 
 ;; Define the format conversion going to and from Org mode/OPML.
 (add-to-list
  'format-alist
- '(opml
+ `(opml
    "Outline Processor Markup Language"
    "<[?]xml version=\"1.0\"[^>]*[?]>[\n]?.*[\n]?.*[\n]?<opml version=\"[1|2].0\">"
-   opml-decode
+   ,opml2org
    opml-encode
    t))
 

--- a/org-opml.el
+++ b/org-opml.el
@@ -1,9 +1,22 @@
+;; Locate the OPML import backend
+(setq opml2org (locate-file "opml2org.py" load-path))
+
+(defun opml-decode (begin end)
+  (call-process-region
+   (point-min) (point-max)
+   opml2org
+   ;; three 't's = redisplay buffer with processed text
+   t t t))
+
 ;; Define the format conversion going to and from Org mode/OPML.
-;;
-;; Change "~/src/org-opml/opml2org.py" to wherever that file is located.
-(add-to-list 'format-alist '(opml "Outline Processor Markup Language"
-                                  "<[?]xml version=\"1.0\"[^>]*[?]>[\n]?.*[\n]?.*[\n]?<opml version=\"[1|2].0\">"
-                                  "~/src/org-opml/opml2org.py" opml-encode t))
+(add-to-list
+ 'format-alist
+ '(opml
+   "Outline Processor Markup Language"
+   "<[?]xml version=\"1.0\"[^>]*[?]>[\n]?.*[\n]?.*[\n]?<opml version=\"[1|2].0\">"
+   opml-decode
+   opml-encode
+   t))
 
 ;; If it ends with .opml, use `opml-encode' when saving.
 (defun set-buffer-file-format-to-opml ()


### PR DESCRIPTION
@tonglianheng Can you take a look at this? I have a bug that I can't figure out: when I open an OPML file, first it fails with the error `Wrong-type-argument: inserted-chars, -1`. Then I try to open it a second time and it works but `org-mode` is not activated - it's just in `Fundamental` mode. Any ideas?
